### PR TITLE
#8: Clear Draft

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "firebase": "^9.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.37.0"
+        "react-hook-form": "^7.42.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.17",
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -2344,9 +2344,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.37.0.tgz",
-      "integrity": "sha512-6NFTxsnw+EXSpNNvLr5nFMjPdYKRryQcelTHg7zwBB6vAzfPIcZq4AExP4heVlwdzntepQgwiOQW4z7Mr99Lsg==",
+      "version": "7.42.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -4357,9 +4357,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jszip": {
@@ -4532,9 +4532,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.37.0.tgz",
-      "integrity": "sha512-6NFTxsnw+EXSpNNvLr5nFMjPdYKRryQcelTHg7zwBB6vAzfPIcZq4AExP4heVlwdzntepQgwiOQW4z7Mr99Lsg==",
+      "version": "7.42.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
       "requires": {}
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "firebase": "^9.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.37.0"
+    "react-hook-form": "^7.42.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -132,9 +132,10 @@ export function TimeEntryForm() {
     // When saving a log, supply the most-recent list for use when saving.
     const entry = getLogFromFormFields(formData, recentList, false /*allowEmptyList*/);
 
+    cancelDraftSave(); // Stop any in-progress drafts from saving so we don't stomp the form state with it.
+
     try {
       await addLog(fBaseContext, entry);
-      cancelDraftSave(); // Stop any in-progress drafts from saving, now that the log is stored successfully.
       reset();
     } catch (err: any) {
       console.error(`Failed to submit form: ${err.message}`);

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -76,7 +76,8 @@ export function TimeEntryForm() {
   const draftSaved = draft?.savedTime?.toDate().toLocaleString() || '';
 
   const { register, handleSubmit, watch, formState: { errors }, reset: useFormReset } = useForm<TimeEntryFormData>({
-    defaultValues: makeDefaultFormValues(recentList, draft?.log)
+    defaultValues: makeDefaultFormValues(recentList, draft?.log),
+    values: getFormFieldsFromLog(draft?.log)
   });
 
   const reset = (evt?: MouseEvent<HTMLButtonElement>) => {

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -86,9 +86,9 @@ export function TimeEntryForm() {
   });
 
   const reset = (evt?: MouseEvent<HTMLButtonElement>) => {
-      evt?.preventDefault(); // Required for form reset to work as expected w/ useForm
-      useFormReset(makeDefaultFormValues(draft?.log));
-    };
+    evt?.preventDefault(); // Required for form reset to work as expected w/ useForm
+    useFormReset(makeDefaultFormValues(draft?.log));
+  };
 
   useEffect(() => {
     // Draft has changed and has data, so reset.
@@ -129,20 +129,19 @@ export function TimeEntryForm() {
     return () => subscription.unsubscribe();
   }, [watch]);
 
-  const submitTimeEntry =
-    async (formData: TimeEntryFormData) => {
-      // When saving a log, supply the most-recent list for use when saving.
-      const entry = getLogFromFormFields(formData, recentList, false /*allowEmptyList*/);
+  const submitTimeEntry = async (formData: TimeEntryFormData) => {
+    // When saving a log, supply the most-recent list for use when saving.
+    const entry = getLogFromFormFields(formData, recentList, false /*allowEmptyList*/);
 
-      cancelDraftSave(); // Stop any in-progress drafts from saving so we don't stomp the form state with it.
+    cancelDraftSave(); // Stop any in-progress drafts from saving so we don't stomp the form state with it.
 
-      try {
-        await addLog(fBaseContext, entry);
-        reset();
-      } catch (err: any) {
-        console.error(`Failed to submit form: ${err.message}`);
-      }
-    };
+    try {
+      await addLog(fBaseContext, entry);
+      reset();
+    } catch (err: any) {
+      console.error(`Failed to submit form: ${err.message}`);
+    }
+  };
 
   const handleDraftDelete = (evt?: MouseEvent<HTMLButtonElement>) => {
     evt?.preventDefault(); // Required for form reset to work as expected w/ useForm

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -48,13 +48,13 @@ function getLogFromFormFields(formFields: TimeEntryFormData, recentList?: string
 }
 
 function getFormFieldsFromLog(log?: ILog) {
-  if (!log) {
-    return {};
-  }
+  // if (!log) {
+  //   return {};
+  // }
   
   const fields: TimeEntryFormData = {
     ...(log?.startTime && { startTime: timeString(log!.startTime!.toDate()) }),
-    ...(log?.endTime && { endTime: timeString(log!.endTime!.toDate()) }),
+    ...(log?.endTime && { endTime: timeString(log!.endTime!.toDate()) } || { endTime: '' }),
     ...(log?.startTime && { dateEntry: dateString(log!.startTime!.toDate()) }),
     note: log?.note || '',
     list: log?.list || ''

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -4,8 +4,9 @@ import { ILog, DEFAULT_LIST, addLog, saveDraft, deleteDraft, useLogs, useAccount
 import { Timestamp } from 'firebase/firestore';
 import { useForm } from 'react-hook-form';
 
-const DRAFT_SAVE_SPEED = 5000; // Save a draft on changes after 5 seconds.
-// const DRAFT_SAVE_SPEED = 1000; // DEBUG: Save a draft on changes after a second.
+const DRAFT_SAVE_SPEED = (import.meta.env.DEV && import.meta.env.MODE !== 'prodfirestore') ?
+  1000: // DEBUG: Save a draft on changes after a second.
+  5000; // Save a draft on changes after 5 seconds.
 
 export function twoDig(singleOrDoubleDigit: number | string) {
   return singleOrDoubleDigit.toString().padStart(2, '0');

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -1,6 +1,6 @@
 import { FirebaseContext } from '../data/FirebaseContext';
-import { useContext, useEffect, useState, MouseEvent } from 'react';
-import { ILog, DEFAULT_LIST, addLog, saveDraft, loadDraft, deleteDraft, useLogs, useAccount } from '../data/logs-collection';
+import { useContext, useEffect, MouseEvent } from 'react';
+import { ILog, DEFAULT_LIST, addLog, saveDraft, deleteDraft, useLogs, useAccount } from '../data/logs-collection';
 import { Timestamp } from 'firebase/firestore';
 import { useForm } from 'react-hook-form';
 

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -84,13 +84,10 @@ export function TimeEntryForm() {
     values: getFormFieldsFromLog(draft?.log)
   });
 
-  const reset = useCallback(
-    (evt?: MouseEvent<HTMLButtonElement>) => {
+  const reset = (evt?: MouseEvent<HTMLButtonElement>) => {
       evt?.preventDefault(); // Required for form reset to work as expected w/ useForm
       useFormReset(makeDefaultFormValues(draft?.log));
-    },
-    [draft, useFormReset]
-  );
+    };
 
   useEffect(() => {
     // Draft has changed and has data, so reset.
@@ -100,7 +97,7 @@ export function TimeEntryForm() {
       const defaultVals = makeDefaultFormValues();
       useFormReset(defaultVals);
     }
-  }, [draft, reset, useFormReset]);
+  }, [draft, useFormReset]);
 
   const draftSaveTimeoutRef: MutableRefObject<number | null> = useRef(null);
   const cancelDraftSave = () => {

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -129,7 +129,7 @@ export function TimeEntryForm() {
     return () => subscription.unsubscribe();
   }, [watch]);
 
-  const submitTimeEntry = useCallback(
+  const submitTimeEntry =
     async (formData: TimeEntryFormData) => {
       // When saving a log, supply the most-recent list for use when saving.
       const entry = getLogFromFormFields(formData, recentList, false /*allowEmptyList*/);
@@ -142,9 +142,7 @@ export function TimeEntryForm() {
       } catch (err: any) {
         console.error(`Failed to submit form: ${err.message}`);
       }
-    },
-    [reset, cancelDraftSave, getLogFromFormFields, addLog]
-  );
+    };
 
   const handleDraftDelete = (evt?: MouseEvent<HTMLButtonElement>) => {
     evt?.preventDefault(); // Required for form reset to work as expected w/ useForm

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -48,10 +48,6 @@ function getLogFromFormFields(formFields: TimeEntryFormData, recentList?: string
 }
 
 function getFormFieldsFromLog(log?: ILog) {
-  // if (!log) {
-  //   return {};
-  // }
-  
   const fields: TimeEntryFormData = {
     ...(log?.startTime && { startTime: timeString(log!.startTime!.toDate()) }),
     ...(log?.endTime && { endTime: timeString(log!.endTime!.toDate()) } || { endTime: '' }),

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -26,7 +26,11 @@ type TimeEntryFormData = {
   note?: string;
 };
 
-function getLogFromFormFields(formFields: TimeEntryFormData, recentList?: string, allowEmptyList: boolean = true) {
+function getLogFromFormFields(
+  formFields: TimeEntryFormData,
+  recentList?: string,
+  allowEmptyList: boolean = true)
+{
   const start = formFields.startTime && Timestamp.fromDate(new Date(`${formFields.dateEntry}T${formFields.startTime}`));
   const end = formFields.endTime && Timestamp.fromDate(new Date(`${formFields.dateEntry}T${formFields.endTime}`));
   
@@ -58,7 +62,7 @@ function getFormFieldsFromLog(log?: ILog) {
   return fields;
 }
 
-function makeDefaultFormValues(recentList?: string, log?: ILog) {
+function makeDefaultFormValues(log?: ILog) {
   return {
     dateEntry: dateString(),
     startTime: timeString(),
@@ -76,16 +80,16 @@ export function TimeEntryForm() {
   const draftSaved = draft?.savedTime?.toDate().toLocaleString() || '';
 
   const { register, handleSubmit, watch, formState: { errors }, reset: useFormReset } = useForm<TimeEntryFormData>({
-    defaultValues: makeDefaultFormValues(recentList, draft?.log),
+    defaultValues: makeDefaultFormValues(draft?.log),
     values: getFormFieldsFromLog(draft?.log)
   });
 
   const reset = useCallback(
     (evt?: MouseEvent<HTMLButtonElement>) => {
       evt?.preventDefault(); // Required for form reset to work as expected w/ useForm
-      useFormReset(makeDefaultFormValues(recentList, draft?.log));
+      useFormReset(makeDefaultFormValues(draft?.log));
     },
-    [draft, recentList, useFormReset]
+    [draft, useFormReset]
   );
 
   useEffect(() => {
@@ -93,8 +97,7 @@ export function TimeEntryForm() {
     if (draft) {
       reset();
     } else {
-      const defaultVals = makeDefaultFormValues(undefined, { note: '', list: '' });
-      defaultVals.endTime = '';
+      const defaultVals = makeDefaultFormValues();
       useFormReset(defaultVals);
     }
   }, [draft, reset, useFormReset]);

--- a/src/data/logs-collection.ts
+++ b/src/data/logs-collection.ts
@@ -4,7 +4,6 @@ import {
   deleteDoc,
   deleteField,
   doc,
-  getDoc,
   onSnapshot,
   query,
   setDoc,
@@ -157,10 +156,4 @@ export function useAccount(fBaseContext: IFirebaseContext) {
   }, [fBaseContext]);
 
   return account;
-}
-
-export async function loadDraft(fBaseContext: IFirebaseContext): Promise<ILogDraft> {
-  const uid = checkedUid(fBaseContext);
-  const userData = await (await getDoc(doc(fBaseContext.db, ACCOUNTS_COLLECTION, uid))).data();
-  return userData!.draft;
 }


### PR DESCRIPTION
Fixes #8 

The log draft was not clearing out properly when a log was submitted. The fix involves:

- Supplying `values` to `useForm`, which is available in a more recent version of `react-hook-form`.
- Cancelling the draft save upon submission of the form.

Some other included changes:

- Draft save speed is faster when running in debug mode w/ the emulators
- "No Data" displays properly when logs is an empty list.
- Remove unused code (`loadDraft` and a `recentList` param)