### PR TITLE
feat: Block deployments for config and docs

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,9 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.github/workflows/*.yml'
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,11 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+'on':
+  pull_request:
+    paths-ignore:
+        - '**/*.md'
+        - '.github/workflows/*.yml'
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'


### PR DESCRIPTION
Don't do deployments or PR releases if the only changes included are in the github actions config or in markdown files.